### PR TITLE
Issue 65 : Quitter Partie (Avant/Après/En Cours)

### DIFF
--- a/src/network/client/ComClient.java
+++ b/src/network/client/ComClient.java
@@ -7,10 +7,14 @@ import java.util.UUID;
 
 import data.ClientDataEngine;
 import data.Profile;
+import network.messages.AcceptReplayMessage;
 import network.messages.ConnectionMessage;
+import network.messages.DropTableMessage;
 import network.messages.GetProfileMessage;
 import network.messages.IMessage;
 import network.messages.LogoutUserRequestMessage;
+import network.messages.QuitGameMessage;
+import network.messages.RefuseReplayMessage;
 import network.messages.UpdateProfileMessage;
 
 public class ComClient implements ComClientInterface{
@@ -98,14 +102,12 @@ public class ComClient implements ComClientInterface{
 
 	@Override
 	public void dropTable(UUID tableId) {
-		// TODO Auto-generated method stub
-		
+		sendMessage(new DropTableMessage(tableId));
 	}
 
 	@Override
 	public void quit(UUID user) {
-		// TODO Auto-generated method stub
-		
+		sendMessage(new QuitGameMessage(user));
 	}
 
 	@Override
@@ -134,14 +136,12 @@ public class ComClient implements ComClientInterface{
 
 	@Override
 	public void acceptReplay(UUID user) {
-		// TODO Auto-generated method stub
-		
+		sendMessage(new AcceptReplayMessage(user));
 	}
 
 	@Override
 	public void refuseReplay(UUID user) {
-		// TODO Auto-generated method stub
-		
+		sendMessage(new RefuseReplayMessage(user));
 	}
 
 	@Override

--- a/src/network/messages/AcceptReplayMessage.java
+++ b/src/network/messages/AcceptReplayMessage.java
@@ -1,0 +1,28 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class AcceptReplayMessage implements IMessage {
+
+	private static final long serialVersionUID = 5399551477085698202L;
+	private UUID user;
+	
+	public AcceptReplayMessage(UUID user) {
+		this.user = user;
+	}
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		dataEngine.hasAcceptedReplay(user);
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/network/messages/HasAcceptedMessage.java
+++ b/src/network/messages/HasAcceptedMessage.java
@@ -1,0 +1,30 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class HasAcceptedMessage implements IMessage {
+
+	private static final long serialVersionUID = 6986290106710598367L;
+
+	private UUID user;
+	
+	public HasAcceptedMessage(UUID user) {
+		this.user = user;
+	}
+	
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// Appeler dataEngine.hasAccepted(user)
+	}
+
+}

--- a/src/network/messages/HasRefusedMessage.java
+++ b/src/network/messages/HasRefusedMessage.java
@@ -1,0 +1,29 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class HasRefusedMessage implements IMessage {
+
+	private static final long serialVersionUID = -5383642164826933945L;
+
+	private UUID user;
+	
+	public HasRefusedMessage(UUID user) {
+		this.user = user;
+	}
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// Appeler dataEngine.hasRefused(user)
+	}
+
+}

--- a/src/network/messages/KickedMessage.java
+++ b/src/network/messages/KickedMessage.java
@@ -1,0 +1,28 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class KickedMessage implements IMessage {
+
+	private static final long serialVersionUID = 6709711021661501877L;
+	private String msg;
+	
+	public KickedMessage(String msg) {
+		this.msg = msg;
+	}
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// Appeler dataEngine.kicked(msg)
+	}
+
+}

--- a/src/network/messages/PlayerQuitGameMessage.java
+++ b/src/network/messages/PlayerQuitGameMessage.java
@@ -1,0 +1,28 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class PlayerQuitGameMessage implements IMessage {
+
+	private static final long serialVersionUID = 1308575889279693465L;
+	private UUID user;
+	
+	public PlayerQuitGameMessage(UUID user) {
+		this.user = user;
+	}
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// Appeler dataEngine.playerQuitGame(user)
+	}
+
+}

--- a/src/network/messages/QuitGameMessage.java
+++ b/src/network/messages/QuitGameMessage.java
@@ -1,16 +1,24 @@
 package network.messages;
 
+import java.util.UUID;
+
 import data.ClientDataEngine;
 import data.ServerDataEngine;
 
 public class QuitGameMessage implements IMessage {
 
 	private static final long serialVersionUID = -506628116565819592L;
-
+	private UUID user;
+	
+	public QuitGameMessage(UUID user) {
+		this.user = user;
+	}
+	
+	
 	@Override
 	public void process(ServerDataEngine dataEngine) {
-		// TODO Auto-generated method stub
-		
+		// dataEngine.quit(user, table); problème je n'ai pas de table, la méthode est quit(UUID user), conformément au diagramme de séquence
+		// conformément au même diagramme la méthode de l'interface Data devrait prendre uniquement un User
 	}
 
 	@Override

--- a/src/network/messages/RefuseReplayMessage.java
+++ b/src/network/messages/RefuseReplayMessage.java
@@ -1,0 +1,28 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.ClientDataEngine;
+import data.ServerDataEngine;
+
+public class RefuseReplayMessage implements IMessage {
+
+	private static final long serialVersionUID = -6693270949227931714L;
+	private UUID user;
+	
+	public RefuseReplayMessage(UUID user) {
+		this.user = user;
+	}
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		dataEngine.hasRefusedReplay(user);
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/network/server/ComServer.java
+++ b/src/network/server/ComServer.java
@@ -9,6 +9,11 @@ import java.util.UUID;
 import data.GameTable;
 import data.Profile;
 import data.ServerDataEngine;
+import network.messages.HasAcceptedMessage;
+import network.messages.HasRefusedMessage;
+import network.messages.KickedMessage;
+import network.messages.LogoutUserRequestMessage;
+import network.messages.PlayerQuitGameMessage;
 import network.messages.SendProfileMessage;
 import data.User;
 
@@ -168,8 +173,13 @@ public class ComServer implements Runnable, ComServerInterface {
 
 	@Override
 	public void kick(List<UUID> receivers, String msg) {
-		// TODO Auto-generated method stub
-		
+		SocketClientHandler handler = connectedClients.get(receivers);
+		if (handler != null) {
+			for(UUID receiver : receivers) {
+				// Il faut pouvoir spécifier à qui on envoie ?
+				handler.sendMessage(new KickedMessage(msg));
+			}
+		}
 	}
 
 	@Override
@@ -204,14 +214,24 @@ public class ComServer implements Runnable, ComServerInterface {
 
 	@Override
 	public void hasAccepted(UUID user, List<UUID> receivers) {
-		// TODO Auto-generated method stub
-		
+		SocketClientHandler handler = connectedClients.get(receivers);
+		if (handler != null) {
+			for(UUID receiver : receivers) {
+				// Il faut pouvoir spécifier à qui on envoie ?
+				handler.sendMessage(new HasAcceptedMessage(user));
+			}
+		}
 	}
 
 	@Override
 	public void hasRefused(UUID user, List<UUID> receivers) {
-		// TODO Auto-generated method stub
-		
+		SocketClientHandler handler = connectedClients.get(receivers);
+		if (handler != null) {
+			for(UUID receiver : receivers) {
+				// Il faut pouvoir spécifier à qui on envoie ?
+				handler.sendMessage(new HasRefusedMessage(user));
+			}
+		}
 	}
 
 	@Override
@@ -271,4 +291,15 @@ public class ComServer implements Runnable, ComServerInterface {
         // TODO Auto-generated method stub
         
     }
+
+	@Override
+	public void playerQuitGame(List<UUID> receivers, UUID user) {
+		SocketClientHandler handler = connectedClients.get(receivers);
+		if (handler != null) {
+			for(UUID receiver : receivers) {
+				// Il faut pouvoir spécifier à qui on envoie ?
+				handler.sendMessage(new PlayerQuitGameMessage(user));
+			}
+		}
+	}
 }

--- a/src/network/server/ComServerInterface.java
+++ b/src/network/server/ComServerInterface.java
@@ -31,4 +31,5 @@ public interface ComServerInterface {
 	public void hasRefused(UUID user,List<UUID> receivers);
 	public void newUser(List<UUID> receivers, Profile user);
 	public void sendTablesUsers(List<User> userList, List<GameTable> tableList, Profile user);
+	public void playerQuitGame(List<UUID> receivers, UUID user);
 }


### PR DESCRIPTION
Fixes #65 

**Méthodes Client :** 

- dropTable
- quit
- acceptReplay
- refuseReplay

**Méthodes Serveur :** 

- kick
- playerQuitGame
- hasAccepted
- hasRefused

**Messages :** 

- AcceptReplayMessage
- HasAcceptedMessage
- RefuseReplayMessage
- HasRefusedMessage
- KickedMessage
- PlayerQuitGameMessage
- QuitGameMessage

En attente du dataEngine pour les méthodes process côté client