### PR TITLE
Méthodes de Quitter Partie (en cours de jeu)

### DIFF
--- a/src/network/client/ComClient.java
+++ b/src/network/client/ComClient.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import data.client.ClientDataEngine;
 import data.Profile;
 import network.messages.AcceptReplayMessage;
+import network.messages.AnswerStopGameMessage;
 import data.Rules;
 import data.User;
 import network.messages.ConnectionMessage;
@@ -22,6 +23,7 @@ import network.messages.QuitGameMessage;
 import network.messages.RefuseReplayMessage;
 import network.messages.UpdateProfileMessage;
 import network.messages.AskJoinTableMessage;
+import network.messages.AskQuitTableMessage;
 import network.messages.askRefreshUserListMessage;
 
 public class ComClient implements ComClientInterface{
@@ -113,6 +115,7 @@ public class ComClient implements ComClientInterface{
 
 	@Override
 	public void quit(UUID user) {
+		// Quit pour le diagramme Quitter Partie (avant/après)
 		sendMessage(new QuitGameMessage(user));
 	}
 
@@ -124,8 +127,7 @@ public class ComClient implements ComClientInterface{
 
 	@Override
 	public void askQuitTable(UUID tableId, UUID user) {
-		// TODO Auto-generated method stub
-		
+		sendMessage(new AskQuitTableMessage(tableId,user));
 	}
 
 	@Override
@@ -199,4 +201,15 @@ public class ComClient implements ComClientInterface{
         // TODO Auto-generated method stub
         
     }
+
+	@Override
+	public void answerStopGame(UUID tableId, boolean answer, UUID user) {
+		sendMessage(new AnswerStopGameMessage(tableId, answer, user));
+	}
+
+	@Override
+	public void quit(UUID user, UUID tableId) {
+		// Quit pour le diagramme Quitter Partie (en cours de jeu)
+		sendMessage(new QuitGameMessage(user, tableId));
+	}
 }

--- a/src/network/client/ComClientInterface.java
+++ b/src/network/client/ComClientInterface.java
@@ -26,4 +26,6 @@ public interface ComClientInterface {
 	//Changement de l'interface pour recuperer le profile 
     //getProfile(UUID user) --> getProfile(UUID user, UUID sender)
 	public void getProfile(UUID user, UUID sender);
+	public void answerStopGame(UUID tableId, boolean answer, UUID user);
+	public void quit(UUID user, UUID tableId);
 }

--- a/src/network/messages/AnswerStopGameMessage.java
+++ b/src/network/messages/AnswerStopGameMessage.java
@@ -1,0 +1,34 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.client.ClientDataEngine;
+import data.server.ServerDataEngine;
+
+public class AnswerStopGameMessage implements IMessage {
+
+	private static final long serialVersionUID = -2651256156377342660L;
+
+    private UUID tableId;
+    private boolean answer;
+    private UUID user;
+    
+    public AnswerStopGameMessage(UUID tableId, boolean answer, UUID userID) {
+    	this.tableId = tableId;
+    	this.answer = answer;
+    	this.user = userID;
+    }
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// Appeler :
+		// dataEngine.answerStopGame(tableId,answer,user);
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/network/messages/AskQuitTableMessage.java
+++ b/src/network/messages/AskQuitTableMessage.java
@@ -1,0 +1,35 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.GameTable;
+import data.Profile;
+import data.User;
+import data.client.ClientDataEngine;
+import data.server.ServerDataEngine;
+
+public class AskQuitTableMessage implements IMessage {
+
+	private static final long serialVersionUID = 2143481984334543591L;
+    private UUID tableId;
+    private UUID user;
+    
+    public AskQuitTableMessage(UUID tableId, UUID userID) {
+    	this.tableId = tableId;
+    	this.user = userID;
+    }
+
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// Ce n'est pas la bonne méthode, il faut une méthode askQuitTable spécifique lorsque le user est admin selon le diagramme
+		// dataEngine.quit(new User(new Profile(user)), new GameTable(tableId));
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/network/messages/AskStopGameMessage.java
+++ b/src/network/messages/AskStopGameMessage.java
@@ -1,0 +1,26 @@
+package network.messages;
+
+import java.util.UUID;
+
+import data.client.ClientDataEngine;
+import data.server.ServerDataEngine;
+
+public class AskStopGameMessage implements IMessage {
+
+	private static final long serialVersionUID = 3413708401686105382L;
+
+	public AskStopGameMessage() {
+    }
+	
+	@Override
+	public void process(ServerDataEngine dataEngine) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void process(ClientDataEngine dataEngine) {
+		dataEngine.askStopGame();
+	}
+
+}

--- a/src/network/messages/QuitGameMessage.java
+++ b/src/network/messages/QuitGameMessage.java
@@ -2,6 +2,9 @@ package network.messages;
 
 import java.util.UUID;
 
+import data.GameTable;
+import data.Profile;
+import data.User;
 import data.client.ClientDataEngine;
 import data.server.ServerDataEngine;
 
@@ -9,9 +12,15 @@ public class QuitGameMessage implements IMessage {
 
 	private static final long serialVersionUID = -506628116565819592L;
 	private UUID user;
+	private UUID tableId;
 	
 	public QuitGameMessage(UUID user) {
 		this.user = user;
+	}
+	
+	public QuitGameMessage(UUID user, UUID tableId) {
+		this.user = user;
+		this.tableId = tableId;
 	}
 	
 	
@@ -19,6 +28,10 @@ public class QuitGameMessage implements IMessage {
 	public void process(ServerDataEngine dataEngine) {
 		// dataEngine.quit(user, table); problème je n'ai pas de table, la méthode est quit(UUID user), conformément au diagramme de séquence
 		// conformément au même diagramme la méthode de l'interface Data devrait prendre uniquement un User
+		
+		// Quitter partie (avant/apr�s) -> quit(user) => la m�thode quit(user) n'existe pas
+		// Quitter partie en cours -> quit(user,table)
+		dataEngine.quit(new User(new Profile(user)), new GameTable(tableId));
 	}
 
 	@Override

--- a/src/network/server/ComServer.java
+++ b/src/network/server/ComServer.java
@@ -14,6 +14,7 @@ import network.messages.NewUserMessage;
 import network.messages.HasSelectedMessage;
 import network.messages.IsTurnMessage;
 import network.messages.HasThrownMessage;
+import network.messages.AskStopGameMessage;
 import network.messages.HasAcceptedMessage;
 import network.messages.HasRefusedMessage;
 import network.messages.KickedMessage;
@@ -224,8 +225,12 @@ public class ComServer implements Runnable, ComServerInterface {
 
 	@Override
 	public void askStopGameEveryUser(List<UUID> receivers) {
-		// TODO Auto-generated method stub
-		
+		for(UUID receiver : receivers) {		
+			SocketClientHandler handler = connectedClients.get(receiver);
+			if (handler != null) {
+				handler.sendMessage(new AskStopGameMessage());
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #121 

Modifications apportées : 

ComClientInterface : 

- answerStopGame(tableId, answer, user)
- quit(user, tableId)

ComClient : 

- askQuitTable(tableId, user)
- answerStopGame(tableId, answer, user)
- quit(user, tableId)

Messages : 

- AnswerStopGameMessage -> pas de méthode answerStopGame() à appeler sur le dataEngine serveur
- AskQuitTableMessage -> pas de méthode askQuitTable(tableId,user) à appeler sur le dataEngine serveur
- AskStopGameMessage
- QuitGameMessage

ComServeur : 

- askStopGameEveryUser(receivers)

